### PR TITLE
I am truly an id10t

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const app = express();
 const PORT = process.env.PORT || 3001;
 
 // Set up Handlebars.js engine with custom helpers
-const hbs = exphbs.create({ helpers });
+const hbs = exphbs.create();
 
 const sess = {
   secret: 'Super secret secret',


### PR DESCRIPTION
 helpers was used in the exphbs.create, so it was no longer defined after the require was removed.